### PR TITLE
Fixed not dismissing on alwaysAuthorization request

### DIFF
--- a/Pod/Source/STLocationRequestController.swift
+++ b/Pod/Source/STLocationRequestController.swift
@@ -198,7 +198,12 @@ class STLocationRequestController: UIViewController, MKMapViewDelegate, CLLocati
                 self.delegate?.locationRequestControllerDidChange(.LocationRequestDidDisappear)
             }
 			break
-			
+		case .AuthorizedAlways:
+            self.delegate?.locationRequestControllerDidChange(.LocationRequestAuthorized)
+            self.dismissViewControllerAnimated(true) {
+                self.delegate?.locationRequestControllerDidChange(.LocationRequestDidDisappear)
+            }
+            break
 		case .Denied:
             self.delegate?.locationRequestControllerDidChange(.LocationRequestDenied)
             self.dismissViewControllerAnimated(true) {


### PR DESCRIPTION
The bug was when you request alwaysAuthorization, the controller won't dismiss since it accounted for just whenInUse and denied.
